### PR TITLE
Use relative link for Release Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This a crate to install and run ssh via [Pallet](http://pallet.github.com/pallet).
 
-[Release Notes](https://github.com/pallet/ssh-crate/blob/master/ReleaseNotes.md)
+[Release Notes](ReleaseNotes.md)
 
 ## Support
 


### PR DESCRIPTION
This gets the README to link to the Release Notes in the same git branch.
